### PR TITLE
Adopter Main Screen Component Created

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -10,6 +10,7 @@ import LoginScreen from "./screens/LoginScreen";
 import RegisterScreen from "./screens/RegisterScreen";
 import OwnerMainScreen from "./screens/OwnerMainScreen";
 import OwnerNewReportScreen from "./screens/OwnerNewReportScreen";
+import AdopterMainScreen from "./screens/AdopterMainScreen";
 
 const Stack = createNativeStackNavigator();
 
@@ -31,6 +32,7 @@ export default function App() {
                 name="Owner-New-Report"
                 component={OwnerNewReportScreen}
               />
+              <Stack.Screen name="Adopter-Main" component={AdopterMainScreen} />
             </Stack.Navigator>
           </NavigationContainer>
         </GestureHandlerRootView>

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-native": "0.74.2",
         "react-native-collapsible": "^1.6.1",
         "react-native-gesture-handler": "^2.16.1",
+        "react-native-map-clustering": "^3.4.2",
         "react-native-maps": "^1.14.0",
         "react-native-reanimated": "^3.10.1",
         "react-native-responsive-screen": "^1.4.2",
@@ -3542,6 +3543,25 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mapbox/geo-viewport": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/geo-viewport/-/geo-viewport-0.4.1.tgz",
+      "integrity": "sha512-5g6eM3EOSl7+0p0VY+vHWEYjUlNzof936VKHTi/NuJVABjbYe8D2NAVJ0qt5C9Np4glUlhKFepgAgQ0OEybrjQ==",
+      "dependencies": {
+        "@mapbox/sphericalmercator": "~1.1.0"
+      }
+    },
+    "node_modules/@mapbox/sphericalmercator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/sphericalmercator/-/sphericalmercator-1.1.0.tgz",
+      "integrity": "sha512-pEsfZyG4OMThlfFQbCte4gegvHUjxXCjz0KZ4Xk8NdOYTQBLflj6U8PL05RPAiuRAMAQNUUKJuL6qYZ5Y4kAWA==",
+      "bin": {
+        "bbox": "bin/bbox.js",
+        "to4326": "bin/to4326.js",
+        "to900913": "bin/to900913.js",
+        "xyz": "bin/xyz.js"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -9649,6 +9669,11 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/kdbush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
+      "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew=="
+    },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
@@ -12366,6 +12391,19 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-map-clustering": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/react-native-map-clustering/-/react-native-map-clustering-3.4.2.tgz",
+      "integrity": "sha512-7VN3ZmOG6gH2THY1VCkrklJmLVxoaY3SyQHuPlNG1CPmL/unPkyAyfDxFoZahf+UxRYIWSbLa9C3oI3Lcswi+Q==",
+      "dependencies": {
+        "@mapbox/geo-viewport": "^0.4.1",
+        "supercluster": "^7.1.0"
+      },
+      "peerDependencies": {
+        "react-native": "*",
+        "react-native-maps": "*"
+      }
+    },
     "node_modules/react-native-maps": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/react-native-maps/-/react-native-maps-1.14.0.tgz",
@@ -13565,6 +13603,14 @@
       "version": "8.2.5",
       "resolved": "https://registry.npmjs.org/sudo-prompt/-/sudo-prompt-8.2.5.tgz",
       "integrity": "sha512-rlBo3HU/1zAJUrkY6jNxDOC9eVYliG6nS4JA8u8KAshITd07tafMc/Br7xQwCSseXwJ2iCcHCE8SNWX3q8Z+kw=="
+    },
+    "node_modules/supercluster": {
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
+      "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
+      "dependencies": {
+        "kdbush": "^3.0.0"
+      }
     },
     "node_modules/supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-native": "0.74.2",
     "react-native-collapsible": "^1.6.1",
     "react-native-gesture-handler": "^2.16.1",
+    "react-native-map-clustering": "^3.4.2",
     "react-native-maps": "^1.14.0",
     "react-native-reanimated": "^3.10.1",
     "react-native-responsive-screen": "^1.4.2",

--- a/screens/AdopterMainScreen.tsx
+++ b/screens/AdopterMainScreen.tsx
@@ -1,0 +1,245 @@
+import { StatusBar } from "expo-status-bar";
+import React, { useState, useEffect, useRef } from "react";
+import { View, Text, Image, TouchableOpacity } from "react-native";
+
+import {
+  widthPercentageToDP as wp,
+  heightPercentageToDP as hp,
+} from "react-native-responsive-screen";
+import { AntDesign } from "@expo/vector-icons";
+import { Ionicons } from "@expo/vector-icons";
+import MapView, { Marker, Region } from "react-native-maps";
+import ClusterMapView from "react-native-map-clustering";
+import * as Location from "expo-location";
+import { NavigationProp } from "@react-navigation/native";
+import { useAuth } from "../context/authContext";
+import { useCats } from "../context/CatContext";
+import { CatData } from "../models/CatData";
+import Animated, { FadeInUp } from "react-native-reanimated";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+interface Location {
+  latitude: number;
+  longitude: number;
+}
+
+const initialRegion: Region = {
+  latitude: 0,
+  longitude: 0,
+  latitudeDelta: 0.02,
+  longitudeDelta: 0.02,
+};
+
+function AdopterMainScreen({
+  navigation,
+}: {
+  navigation: NavigationProp<any>;
+}) {
+  const { logout, user, getUserById } = useAuth();
+  const { getCats, cats } = useCats();
+  const [myLocation, setMyLocation] = useState<Location | null>(null);
+  const [region, setRegion] = useState<Region>(initialRegion);
+  const [filteredCats, setFilteredCats] = useState<CatData[]>([]);
+  const [numNovedades, setNumNovedades] = useState<number>(0);
+  const mapRef = useRef<MapView | null>(null);
+
+  useEffect(() => {
+    const getLocation = async () => {
+      let { status } = await Location.requestForegroundPermissionsAsync();
+      if (status !== "granted") {
+        console.warn("Permission to access location was denied");
+        return;
+      }
+
+      let location = await Location.getCurrentPositionAsync({});
+      const { latitude, longitude } = location.coords;
+      setMyLocation({ latitude, longitude });
+
+      const newRegion = {
+        latitude,
+        longitude,
+        latitudeDelta: 0.02,
+        longitudeDelta: 0.02,
+      };
+      setRegion(newRegion);
+      if (mapRef.current) {
+        mapRef.current.animateToRegion(newRegion, 1000);
+      }
+    };
+
+    getLocation();
+  }, []);
+
+  useEffect(() => {
+    const fetchCats = async () => {
+      try {
+        const userId = await AsyncStorage.getItem("userId");
+        if (userId) {
+          await getCats();
+          const notAdoptedCats = cats.filter(
+            (cat: CatData) =>
+              !cat.adopted && !(cat.adopterId && cat.adopterId.includes(userId))
+          );
+          const novedadesCats = cats.filter(
+            (cat: CatData) => cat.adopterId && cat.adopterId.includes(userId)
+          );
+          setFilteredCats(notAdoptedCats);
+          setNumNovedades(novedadesCats.length);
+        }
+      } catch (error) {
+        console.error("Error fetching cats:", error);
+      }
+    };
+
+    fetchCats();
+  }, [cats]);
+
+  const handleCatPress = async (cat: CatData) => {
+    try {
+      const owner = await getUserById(cat.ownerId);
+      if (owner) {
+        navigation.navigate("Adopter-Cat-Details", { cat, owner });
+      }
+    } catch (error) {
+      console.error("Error fetching owner details:", error);
+    }
+  };
+
+  const renderCustomMarker = (cat: CatData) => {
+    if (!cat.adopted) {
+      return (
+        <Marker
+          key={cat._id}
+          coordinate={{ latitude: cat.lat, longitude: cat.lng }}
+          onPress={() => handleCatPress(cat)}
+        >
+          <View
+            className="items-center justify-center border-[#6EADE1] border-4 rounded-full"
+            style={{ width: 70, height: 70, backgroundColor: "white" }}
+          >
+            <Image
+              source={{ uri: cat.image }}
+              style={{ width: 60, height: 60, borderRadius: 30 }}
+            />
+          </View>
+        </Marker>
+      );
+    } else {
+      return null;
+    }
+  };
+
+  const handleLogout = async () => {
+    logout();
+    navigation.navigate("Login");
+  };
+
+  const handleNovedadesPress = () => {
+    navigation.navigate("Adopter-Applications-Status");
+  };
+
+  return (
+    <View className="flex-1 bg-white space-y-6 pt-14">
+      <StatusBar style="dark" />
+
+      <View className="mx-4 bg-gray-100 rounded-3xl p-1 mb-16">
+        {user && (
+          <View className=" flex-row justify-between items-center">
+            <View className="flex-row items-center">
+              <Image
+                source={{ uri: user.image }}
+                className="h-12 w-12 mr-2 rounded-full ml-2"
+              />
+              <Text className="text-[#2B26AD] font-bold tracking-wider text-xl">
+                {user.username}
+              </Text>
+            </View>
+            <TouchableOpacity
+              onPress={handleLogout}
+              className="flex-row items-center"
+            >
+              <View className="flex-row items-center">
+                <Text className="text-[#2B26AD] font-bold tracking-wider text-xl mr-2">
+                  Salir
+                </Text>
+                <AntDesign
+                  name="rightcircle"
+                  size={24}
+                  color="#2B26AD"
+                  style={{ marginRight: 8 }}
+                />
+              </View>
+            </TouchableOpacity>
+          </View>
+        )}
+      </View>
+      <Animated.View
+        className="flex-row justify-center items-center bg-gray-100 rounded-xl p-2 mb-8"
+        style={{ alignSelf: "center" }}
+        entering={FadeInUp.delay(400).duration(1000).springify()}
+      >
+        <Ionicons
+          name="search-circle"
+          size={24}
+          color="#2B26AD"
+          style={{ marginRight: 8 }}
+        />
+        <Text className="text-[#2B26AD] font-bold tracking-wider text-2xl">
+          Gatitos Cercanos
+        </Text>
+      </Animated.View>
+
+      <Animated.View
+        className="self-center rounded-3xl border-[#6EADE1] border-4 overflow-hidden"
+        entering={FadeInUp.delay(600).duration(1000).springify()}
+        style={{
+          width: wp(90),
+          height: hp(55),
+        }}
+      >
+        {region.latitude !== 0 && region.longitude !== 0 && (
+          <ClusterMapView
+            style={{ width: "100%", height: "100%" }}
+            region={region}
+            onRegionChangeComplete={setRegion}
+            ref={mapRef}
+            provider="google"
+            zoomControlEnabled={true}
+          >
+            {myLocation && (
+              <Marker
+                coordinate={{
+                  latitude: myLocation.latitude,
+                  longitude: myLocation.longitude,
+                }}
+                pinColor="#FF0000"
+                tracksViewChanges={false}
+              />
+            )}
+            {filteredCats.map((cat) => renderCustomMarker(cat))}
+          </ClusterMapView>
+        )}
+      </Animated.View>
+
+      <Animated.View
+        className="justify-end items-center mt-12"
+        entering={FadeInUp.delay(800).duration(1000).springify()}
+      >
+        <View className="relative w-11/12 bg-[#6EADE1] rounded-3xl p-4 items-center justify-center h-24 ">
+          <TouchableOpacity onPress={handleNovedadesPress}>
+            <Text className="text-white text-4xl font-bold tracking-wider">
+              Novedades
+            </Text>
+            <View className="absolute top-[-42] right-[-118] bg-[#2B26AD] rounded-full h-12 w-12 items-center justify-center">
+              <Text className="text-white text-2xl font-bold">
+                {numNovedades}
+              </Text>
+            </View>
+          </TouchableOpacity>
+        </View>
+      </Animated.View>
+    </View>
+  );
+}
+
+export default AdopterMainScreen;


### PR DESCRIPTION
**En la presente Pull Request:**

**Se instaló la siguiente dependencia:**

- react-native-map-clustering

**Se creó el componente `AdopterMainScreen.tsx`:** Esta screen es la que se visualizará luego de que los usuarios de tipo "adopter" hayan iniciado sesión correctamente. Esta pantalla presenta las siguientes características:

- **"Gatitos Cercanos":** Se muestra un mapa, con markers personalizados, que contienen el "Cat Avatar" de cada gatito publicado para su adopción, ubicados en sus correspondientes coordenadas.
- **Botón "Novedades":** Se muestra un "badge" con la cantidad de novedades respecto de sus postulaciones a adopción de los gatitos a los que aplicó.

La idea es que cuando haga touch sobre algún "Cat Avatar", sea redirigido a una screen que muestre todos los detalles del mismo.
Además el botón de Novedades, redirigirá a una screen donde se muestre el "status" de cada aplicación a adopción, como: "En Revisión", "Aprobado" y "No Aprobado".

**Lógica del componente:** Cuando se monta el componente, a través de un useEffect, primero a través de la función "getLocation" se obtiene la ubicación en tiempo real del usuario, y luego mediante otro useEffect y la función "fetchCats" se solicita a la api toda el Array de objetos "cat" (getCats) y se le aplican 2 "filtros":
1) el primero es una consulta de que el gatito no esté adoptado (prop. "adopted" con valor "false") y que no el usuario no se haya postulado en la adopción de éste (que su id no esté presente en el array de id de la prop. "adopterId"). Este "filtro" es el que deja disponibles para su renderización a los gatitos que no hayan sido adoptados y que el usuario no aplicó para su adopción, con la finalidad de que luego este grupo de gatitos sea mostrado en el mapa.
2) El segundo "filtro" es para obtener el número total de objetos cat que en su propiedad "adopterId" si está presente el id del usuario, para contabilizar la cantidad de postulaciones de éste y mostrar este número en el badge del botón "Novedades".

Además se ha configurado que cuando se pulse un "Cat Avatar" se rediriga a una screen a desarrollar en próximas tareas, para mostrar todos los datos del gatito, como el usuario de tipo "owner" que lo ha publicado para su posterior adopción, lo mismo con la funcionalidad de "Novedades".
Además esta screen cuenta con la funcionalidad de "log out" para cerrar sesión.

**UX/UI del componente:**

- **Barra de Información:** Muestra la imagen y nombre del usuario en sesión, y el ícono "rightcircle" de la librería expo/vector-icons para cerrar sesión.
- **Mapa de búsqueda de "Gatitos Cercanos":** Se muestra el mapa de la librería "react-native-maps" con la ubicación actual del usuario "adopter", y los markers personalizados correspondientes a los gatitos publicados. En caso de aparecer muchos markers en una misma zona, se activa la funcionalidad de la librería react-native-map-clustering indicando el total de markers en la zona.
- **"Cat Avatar":** Son markers que se muestran con la imagen de cada gatito, es decir, se renderiza la propiedad "image" y se posiciona en la lat y lng almacenadas en el mismo objeto "cat".
- **Botón de "Novedades":** El mismo redirigirá a la screen donde se muestre detalladamente las postulaciones del usuario "adopter". Cuenta con un badge informativo para que se muestre el número de postulaciones activas.

Se han realizado pruebas exhaustivas y no se han encontrado errores.

Se aguarda a la revisión de la presente Pull Request, su discusión y correspondiente merge a la rama Main del proyecto.